### PR TITLE
Fix the build.zig file for latest Zig compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,19 +1,23 @@
-const Builder = @import("std").build.Builder;
+const std = @import("std");
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const exe = b.addExecutable("crisp", "src/main.zig");
-
-    exe.setBuildMode(mode);
-
-    exe.addPackage(.{
-        .name = "zig-terminal",
-        .path = "deps/zig-terminal/src/main.zig",
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const exe = b.addExecutable(.{
+        .name = "crisp",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
     });
 
-    exe.install();
+    const terminal_module = b.createModule(.{
+        .source_file = .{ .path = "deps/zig-terminal/src/main.zig" },
+    });
+    exe.addModule("zig-terminal", terminal_module);
 
-    const run_cmd = exe.run();
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
 
     const run_step = b.step("run", "Run the app");


### PR DESCRIPTION
This will only fix our `build.zip` which is now in-line with the latest Zig v0.11.0.

The build will still fail however, but that is due to the to the `zig-terminal` dep:

```
deps/zig-terminal/src/main.zig:50:30: error: struct 'target.Target' has no member named 'current'
const is_windows = std.Target.current.os.tag == .windows;
                   ~~~~~~~~~~^~~~~~~~
/usr/lib/zig/std/target.zig:6:20: note: struct declared here
pub const Target = struct {
```
